### PR TITLE
Pr add change type label

### DIFF
--- a/.github/workflows/prepare-new-pr.yml
+++ b/.github/workflows/prepare-new-pr.yml
@@ -1,0 +1,20 @@
+name: 'Prepare new PR'
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  prepare-new-issue:
+    runs-on: ubuntu-latest
+    # if: ${{ github.repository_owner == 'open-telemetry' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run update permissions
+        run: chmod +x ./.github/workflows/scripts/prepare-new-pr.sh
+
+      - name: Run prepare-new-pr.sh
+        run: ./.github/workflows/scripts/prepare-new-pr.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}

--- a/.github/workflows/scripts/prepare-new-pr.sh
+++ b/.github/workflows/scripts/prepare-new-pr.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+PR="$1"
+
+if [ -z ${PR:-} ]; then
+    echo "PR number is required"
+    exit 1
+fi
+
+# set -o xtrace
+
+CHLOG="$(gh pr view $PR --json files --jq '.files.[].path | select (. | startswith(".chloggen/"))')"
+echo "Change log file: ${CHLOG}"
+
+COUNT="$(echo "$CHLOG" | wc -l)"
+if [ -z "$CHLOG" ]; then
+    echo "No changelog found in the PR. Ignoring this change."
+    exit 0
+fi
+
+if [ $COUNT -eq 1 ]; then
+    CHANGE_TYPE=$(awk -F': ' '/^change_type:/ {print $2}' $CHLOG | xargs)
+    echo $CHANGE_TYPE
+    gh pr edit "${PR}" --add-label "${CHANGE_TYPE}" || true
+else
+    echo "Found multiple changelogs - $CHLOG. Ignoring this change."
+fi
+
+exit 0

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+aliases: [attribute-naming]
+--->
+
 # Naming
 
 **Status**: [Stable][DocumentStatus], Unless otherwise specified.


### PR DESCRIPTION
Fixes #

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
